### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/include/lsst/meas/deblender/Baseline.h
+++ b/include/lsst/meas/deblender/Baseline.h
@@ -74,13 +74,13 @@ namespace lsst {
                 apportionFlux(MaskedImageT const& img,
                               lsst::afw::detection::Footprint const& foot,
                               std::vector<typename PTR(lsst::afw::image::Image<ImagePixelT>)> templates,
-                              std::vector<boost::shared_ptr<lsst::afw::detection::Footprint> > templ_footprints,
+                              std::vector<std::shared_ptr<lsst::afw::detection::Footprint> > templ_footprints,
                               //
                               ImagePtrT templ_sum,
                               std::vector<bool> const& ispsf,
                               std::vector<int>  const& pkx,
                               std::vector<int>  const& pky,
-                              std::vector<boost::shared_ptr<typename lsst::afw::detection::HeavyFootprint<ImagePixelT,MaskPixelT,VariancePixelT> > > & strays,
+                              std::vector<std::shared_ptr<typename lsst::afw::detection::HeavyFootprint<ImagePixelT,MaskPixelT,VariancePixelT> > > & strays,
                               int strayFluxOptions,
                               double clipStrayFluxFraction
                      );
@@ -88,13 +88,13 @@ namespace lsst {
                 static
                 bool
                 hasSignificantFluxAtEdge(ImagePtrT,
-                                         boost::shared_ptr<lsst::afw::detection::Footprint>,
+                                         std::shared_ptr<lsst::afw::detection::Footprint>,
                     ImagePixelT threshold);
 
                 static
-                boost::shared_ptr<lsst::afw::detection::Footprint>
+                std::shared_ptr<lsst::afw::detection::Footprint>
                 getSignificantEdgePixels(ImagePtrT,
-                                         boost::shared_ptr<lsst::afw::detection::Footprint>,
+                                         std::shared_ptr<lsst::afw::detection::Footprint>,
                                          ImagePixelT threshold);
 
 
@@ -109,12 +109,12 @@ namespace lsst {
                              ImagePtrT tsum,
                              MaskedImageT const& img,
                              int strayFluxOptions,
-                             std::vector<boost::shared_ptr<lsst::afw::detection::Footprint> > tfoots,
+                             std::vector<std::shared_ptr<lsst::afw::detection::Footprint> > tfoots,
                              std::vector<bool> const& ispsf,
                              std::vector<int>  const& pkx,
                              std::vector<int>  const& pky,
                              double clipStrayFluxFraction,
-                             std::vector<boost::shared_ptr<typename lsst::afw::detection::HeavyFootprint<ImagePixelT,MaskPixelT,VariancePixelT> > > & strays);
+                             std::vector<std::shared_ptr<typename lsst::afw::detection::HeavyFootprint<ImagePixelT,MaskPixelT,VariancePixelT> > > & strays);
 
             };
         }

--- a/python/lsst/meas/deblender/deblenderLib.i
+++ b/python/lsst/meas/deblender/deblenderLib.i
@@ -12,7 +12,7 @@ Python interface to lsst::meas::deblender classes
 %{
 #include <exception>
 #include <list>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "lsst/meas/deblender/Baseline.h"
 #include "lsst/afw/table.h"
 #include "lsst/afw/detection.h"

--- a/src/Baseline.cc
+++ b/src/Baseline.cc
@@ -294,12 +294,12 @@ _find_stray_flux(det::Footprint const& foot,
                  std::vector<int>  const& pkx,
                  std::vector<int>  const& pky,
                  double clipStrayFluxFraction,
-                 std::vector<boost::shared_ptr<typename det::HeavyFootprint<ImagePixelT,MaskPixelT,VariancePixelT> > > & strays
+                 std::vector<std::shared_ptr<typename det::HeavyFootprint<ImagePixelT,MaskPixelT,VariancePixelT> > > & strays
                  ) {
 
     typedef typename det::Footprint::SpanList SpanList;
     typedef typename det::HeavyFootprint<ImagePixelT, MaskPixelT, VariancePixelT> HeavyFootprint;
-    typedef typename boost::shared_ptr< HeavyFootprint > HeavyFootprintPtrT;
+    typedef typename std::shared_ptr< HeavyFootprint > HeavyFootprintPtrT;
 
     // when doing stray flux: the footprints and pixels, which we'll
     // combine into the return 'strays' HeavyFootprint at the end.
@@ -587,7 +587,7 @@ apportionFlux(MaskedImageT const& img,
               std::vector<bool> const& ispsf,
               std::vector<int>  const& pkx,
               std::vector<int>  const& pky,
-              std::vector<boost::shared_ptr<typename det::HeavyFootprint<ImagePixelT,MaskPixelT,VariancePixelT> > > & strays,
+              std::vector<std::shared_ptr<typename det::HeavyFootprint<ImagePixelT,MaskPixelT,VariancePixelT> > > & strays,
               int strayFluxOptions,
               double clipStrayFluxFraction
     ) {
@@ -1311,7 +1311,7 @@ hasSignificantFluxAtEdge(ImagePtrT img,
  *sfoot* in image *img*, above threshold *thresh*.
  */
 template<typename ImagePixelT, typename MaskPixelT, typename VariancePixelT>
-boost::shared_ptr<det::Footprint>
+std::shared_ptr<det::Footprint>
 deblend::BaselineUtils<ImagePixelT,MaskPixelT,VariancePixelT>::
 getSignificantEdgePixels(ImagePtrT img,
                          PTR(det::Footprint) sfoot,


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
