### PR TITLE
Review for DM-9316: tests broken with NumPy 1.12

### DIFF
--- a/tests/testEdges.py
+++ b/tests/testEdges.py
@@ -194,7 +194,7 @@ class RampEdgeTestCase(lsst.utils.tests.TestCase):
             monos = []
             symm1ds = []
             mono1ds = []
-            yslice = H/2
+            yslice = H//2
             parent1d = img[yslice, :]
             for i, dpk in enumerate(deb.deblendedParents[0].peaks):
                 symm = dpk.origTemplate


### PR DESCRIPTION
As of NumPy 1.12, yslice is required to be an integer for indexing NumPy
arrays.