### PR TITLE
DM-33157: Fix doxygen errors in pipe_tasks

### DIFF
--- a/ups/meas_deblender.cfg
+++ b/ups/meas_deblender.cfg
@@ -3,7 +3,7 @@
 import lsst.sconsUtils
 
 dependencies = {
-    "required": ["utils", "afw", "meas_algorithms", "pybind11"],
+    "required": ["afw", "meas_algorithms", "pybind11"],
     "buildRequired": ["boost_test", "pybind11"],
 }
 


### PR DESCRIPTION
This PR prevents a "missing tag file" error when building docs in `meas_deblender` or downstream packages like `pipe_tasks`.