### PR TITLE
DM-48145: Weaken overzealous schema assertion.

### DIFF
--- a/python/lsst/meas/deblender/sourceDeblendTask.py
+++ b/python/lsst/meas/deblender/sourceDeblendTask.py
@@ -275,7 +275,7 @@ class SourceDeblendTask(pipeBase.Task):
             SourceCatalog containing sources detected on this exposure.
         """
         psf = exposure.getPsf()
-        assert sources.getSchema() == self.schema
+        assert sources.getSchema().contains(self.schema), "runtime schema is not compatible with init schema"
         self.deblend(exposure, sources, psf)
 
     def _getPsfFwhm(self, psf, position):


### PR DESCRIPTION
If the schema has columns we don't care about as well as all of the ones we do, that's fine.